### PR TITLE
Add explicit Java module descriptor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11, 17, 20 ]
+    name: Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      - name: Build
+        run: mvn -ntp -B verify

--- a/pom.xml
+++ b/pom.xml
@@ -299,4 +299,46 @@ limitations under the License.
         <gpg.skip>true</gpg.skip>
         <proguard.skip>true</proguard.skip>
     </properties>
+    <profiles>
+        <profile>
+            <id>java-module</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.moditect</groupId>
+                        <artifactId>moditect-maven-plugin</artifactId>
+                        <version>1.0.0.RC3</version>
+                        <executions>
+                                cution>
+                                <id>add-module-infos</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>add-module-info</goal>
+                                </goals>
+                                <configuration>
+                                    <jvmVersion>9</jvmVersion>
+                                    <overwriteExistingFiles>true</overwriteExistingFiles>
+                                    <module>
+                                        <moduleInfo>
+                                            <name>com.ethlo.time</name>
+                                            <!-- export everything -->
+                                            <exports>*;</exports>
+                                            <!-- declare services consumed by the artifact -->
+                                            <addServiceUses>true</addServiceUses>
+                                        </moduleInfo>
+                                    </module>
+                                    <jdepsExtraArgs>
+                                        <arg>--multi-release=9</arg>
+                                    </jdepsExtraArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fixes #14

```
$ jarviz bytecode show --file target/itu-1.7.1.jar 
subject: itu-1.7.1.jar
Unversioned classes. Bytecode version: 52 (Java 8) total: 18
Versioned classes 9. Bytecode version: 53 (Java 9) total: 1

$ jarviz manifest show --file target/itu-1.7.1.jar 
subject: itu-1.7.1.jar
Manifest-Version: 1.0
Created-By: Maven JAR Plugin 3.3.0
Build-Jdk-Spec: 11
Multi-Release: true

$ jarviz module descriptor --file target/itu-1.7.1.jar 
subject: itu-1.7.1.jar
name: com.ethlo.time
version: 1.7.1
open: false
automatic: false
exports:
  com.ethlo.time
  com.ethlo.time.internal
requires:
  java.base mandated
```

**Note:** The `com.ethlo.time.internal` package is exported by default. If you'd like to hide it then change the settings of the moditect plugin to only export the `com.ethlo.time` package.