### PR TITLE
added osgi support through maven bundle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@ limitations under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ethlo.time</groupId>
+    <packaging>bundle</packaging>
     <artifactId>itu</artifactId>
     <version>1.7.3-SNAPSHOT</version>
     <name>Internet Time Utility</name>
@@ -267,6 +268,19 @@ limitations under the License.
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            com.ethlo.time
+                        </Export-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
         <extensions>


### PR DESCRIPTION
Made com.ethlo.time:itu compatible as an OSGI bundle. No changes to the code or documentation. Everything was left as it was. The only changes are found in the pom.xml. Thorugh the use of the maven plugin "maven-bundle-plugin", when compiled thorugh maven, all necessary OSGI bundle data is added to the manifest inside the .jar file.

- Added maven-bundle-plugin to pom.xml 
- Added bundle packaging to pom.xml